### PR TITLE
[Templates] Use AmberCLI::ReloadHandler

### DIFF
--- a/src/amber_cli/templates/app/config/routes.cr
+++ b/src/amber_cli/templates/app/config/routes.cr
@@ -12,7 +12,7 @@ Amber::Server.configure do
     plug Amber::Pipe::CSRF.new
 
     # Reload clients browsers (development only)
-    plug Amber::Pipe::Reload.new if Amber.env.development?
+    plug AmberCLI::ReloadHandler.new if Amber.env.development?
   end
 
   pipeline :api do


### PR DESCRIPTION
Since the Reload feature has been decoupled from Amber lib
the reload needs to the correct handler.